### PR TITLE
#159289842 Client/Postman should be able to update an entry for a particular user

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ About
 
 ### MyDiary is an online journal where users can pen down their thoughts and feelings.
 Users can create an account or login if they already have one, they can add entries to their diary and can also view and edit entries.
-[![Build Status](https://travis-ci.org/Alameen688/MyDiary.svg?branch=develop)](https://travis-ci.org/Alameen688/MyDiary) [![Coverage Status][![Coverage Status](https://coveralls.io/repos/github/Alameen688/MyDiary/badge.svg?branch=develop)](https://coveralls.io/github/Alameen688/MyDiary?branch=develop)
+
+[![Build Status](https://travis-ci.org/Alameen688/MyDiary.svg?branch=develop)](https://travis-ci.org/Alameen688/MyDiary) [![Coverage Status](https://coveralls.io/repos/github/Alameen688/MyDiary/badge.svg?branch=develop)](https://coveralls.io/github/Alameen688/MyDiary?branch=develop)

--- a/dist/router/modules/entries.js
+++ b/dist/router/modules/entries.js
@@ -41,8 +41,8 @@ router.get('/:id', [_auth2.default.isValid, (0, _expressValidation2.default)(_in
 });
 
 // update entry
-router.put('/:id', [_auth2.default.isValid, (0, _expressValidation2.default)(_index2.default.Entry.update)], function (req, res) {
-  entry.update(req, res);
+router.put('/:id', [_auth2.default.isValid, (0, _expressValidation2.default)(_index2.default.Entry.update)], function (req, res, next) {
+  entry.update(req, res, next);
 });
 
 // delete entry

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express-validation": "^1.0.2",
     "joi": "^13.4.0",
     "jsonwebtoken": "^8.3.0",
+    "moment": "^2.22.2",
     "morgan": "^1.9.0",
     "pg": "^7.4.3"
   },

--- a/src/controller/entryController.js
+++ b/src/controller/entryController.js
@@ -63,29 +63,65 @@ class EntryController extends ClientController {
       });
   }
 
-
-  update(req, res) {
+  update(req, res, next) {
     const { id } = req.params;
     const { body } = req;
-    const result = this._entry.updateEntry(id, body);
-    if (result !== null) {
-      res.status(200)
-        .json({
-          status: 'success',
-          data: result,
-        });
-    } else {
-      // has error property to match the pattern of validation error response
-      res.status(404)
-        .json({
-          status: 'error',
-          message: 'Oops entry not found',
-          errors: [
-            "entry with id doesn't exist",
-          ],
-        });
-    }
+
+    const q = `SELECT date_part('day', created_at) as created_day,
+    date_part('month', created_at) as created_month,
+    date_part('year', created_at) as created_year,
+    date_part('day', CURRENT_DATE) as this_day,
+    date_part('month', CURRENT_DATE) as this_month,
+    date_part('year', CURRENT_DATE) as this_year
+    FROM entries WHERE id=($1) AND user_id=($2)`;
+    const v = [id, req.userData.id];
+    const selectQuery = {
+      text: q,
+      values: v,
+    };
+    this._client.query(selectQuery)
+      .then((result) => {
+        if (result.rowCount > 0) {
+          // alow edit for entries only on the same day it was created
+          if (result.rows[0].created_day === result.rows[0].this_day
+            && result.rows[0].created_month === result.rows[0].this_month
+            && result.rows[0].created_year === result.rows[0].this_year) {
+            const action = `UPDATE entries SET title=($1), content=($2), updated_at=($3)
+              WHERE id=($4) AND user_id=($5) RETURNING *`;
+            const values = [body.title, body.content, 'NOW()', id, req.userData.id];
+            const updateQuery = {
+              text: action,
+              values,
+            };
+            this._client.query(updateQuery)
+              .then((output) => {
+                res.status(200)
+                  .json({
+                    status: 'success',
+                    data: output.rows[0],
+                  });
+              })
+              .catch((err) => {
+                next(err);
+              });
+          } else {
+            res.status(400)
+              .json({
+                status: 'error',
+                message: 'Sorry, an entry can only be updated the same day it was created',
+              });
+          }
+        } else {
+          const error = new Error("Entry doesn't exist");
+          error.status = 404;
+          next(error);
+        }
+      })
+      .catch((e) => {
+        next(e);
+      });
   }
+
 
   delete(req, res) {
     const { id } = req.params;

--- a/src/router/modules/entries.js
+++ b/src/router/modules/entries.js
@@ -23,8 +23,8 @@ router.get('/:id', [auth.isValid, validate(Validation.Entry.getById)], (req, res
 });
 
 // update entry
-router.put('/:id', [auth.isValid, validate(Validation.Entry.update)], (req, res) => {
-  entry.update(req, res);
+router.put('/:id', [auth.isValid, validate(Validation.Entry.update)], (req, res, next) => {
+  entry.update(req, res, next);
 });
 
 // delete entry


### PR DESCRIPTION
#### What does this PR do?
Implements the update of an entry created by a particular
user and also allows entry to be updated only on the same day it was created
#### Description of Task to be completed?
Have the update entry endpoint working
/PUT /api/v1/entries/<entry_id>
#### How should this be manually tested?
After cloning the repo, cd into it then
- make sure you have postgresql installed on your machine and start it.
- add a postgreSQL DATABASE_URL to your .env file
   ```
     DATABASE_URL=postgresql://username:password@localhost:5432/mydiarydb
   ```
- The RUN `npm run migrate` to create the database tables.
- Login with an existing user account via /POST api/v1/users/login
  or register at /POST api/v1/users/signup
- send a request body containing
```
{
	"title": "An new entry title",
	"content": "Content goes here"
}
```
to /PUT /api/v1/entries/<entry_id> where `entry_id` is the id of the entry to be updated 
- make sure to put the token gotten from logging in earlier in your authorization header in Postman (Client) `"Authorization" : "Bearer <the_token_here>"`
- you should get a 200 OK response after the post must have been updated for that user
- If the date the entry was created differs from the date of the day you are trying to edit it, you should get  400 response because you can only update an entry the same day it was created
- And if entry is not found you should get a 404
#### Any background context you want to provide?
none
#### What are the relevant pivotal tracker stories?
#159289842