### PR TITLE
#159333304 Change route /api/v1/users to /api/v1/auth

### DIFF
--- a/dist/controller/entryController.js
+++ b/dist/controller/entryController.js
@@ -129,10 +129,7 @@ var EntryController = function (_ClientController) {
 
       this._client.query('DELETE FROM entries WHERE id=($1) AND user_id=($2)', [id, req.userData.id]).then(function (result) {
         if (result.rowCount > 0) {
-          res.status(204).json({
-            status: 'success',
-            data: result.rows
-          });
+          res.status(204);
         } else {
           var error = new Error("Entry doesn't exist");
           error.status = 404;

--- a/dist/server.js
+++ b/dist/server.js
@@ -41,7 +41,7 @@ app.all('/*', function (req, res, next) {
 });
 
 app.use('/api/v1/entries', _index2.default.entries);
-app.use('/api/v1/users', _index2.default.users);
+app.use('/api/v1/auth', _index2.default.users);
 
 // when there is no fitting route set error and run the next func
 app.use(function (req, res, next) {

--- a/src/server.js
+++ b/src/server.js
@@ -23,7 +23,7 @@ app.all('/*', (req, res, next) => {
 });
 
 app.use('/api/v1/entries', router.entries);
-app.use('/api/v1/users', router.users);
+app.use('/api/v1/auth', router.users);
 
 // when there is no fitting route set error and run the next func
 app.use((req, res, next) => {


### PR DESCRIPTION
#### What does this PR do?
Delivers the changing of route from /api/v1/users to
/api/v1/auth as auth is what is used in the product document giving
#### Description of Task to be completed?
Any request formerly made to /api/v1/users will no longer be found but will now be available 
at /api/v1/auth
#### How should this be manually tested?
- test any /api/v1/users endpoint and it should return a 404 but when changed to /api/v1/auth, it will work
- /POST /api/v1/users/signup is now /POST /api/v1/auth/signup
- /POST /api/v1/users/login /POST /api/v1/auth/login
#### Any background context you want to provide?
none
#### What are the relevant pivotal tracker stories?
#159333304